### PR TITLE
added `addScriptTag` parameter to `generate` method in order to reflect the SchemaOrg.toJsonLd structure

### DIFF
--- a/Service/JsonLd.php
+++ b/Service/JsonLd.php
@@ -58,7 +58,7 @@ class JsonLd implements ContainerAwareInterface
      *
      * @throws \Exception
      */
-    public function generate($object)
+    public function generate($object, $addScriptTag = true)
     {
         if (!is_object($object)) {
             throw new \Exception('Expected object, got '.gettype($object).'.');
@@ -67,7 +67,7 @@ class JsonLd implements ContainerAwareInterface
         $transformer = $this->getTransformer($object);
         $schemaOrg = new SchemaOrg();
 
-        return $schemaOrg->toJsonLd($transformer->transform($object));
+        return $schemaOrg->toJsonLd($transformer->transform($object), $addScriptTag);
     }
 
     /**


### PR DESCRIPTION
I need to print the JSON LD structure without the html tag <script>